### PR TITLE
Travis CI: Do not hard-code Trusty, it EOLs this month

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 # Julia for Travis: http://docs.travis-ci.com/user/languages/julia/
 
-dist: trusty
 install:
   - wget http://download.drobilla.net/serd-0.30.0.tar.bz2
   - tar -vxjf serd-0.30.0.tar.bz2


### PR DESCRIPTION
Do not hard-code __Trusty__ because it reaches its end-of-life this month.
https://wiki.ubuntu.com/Releases